### PR TITLE
Fixed invalid escape sequence in MQTT publisher

### DIFF
--- a/front/plugins/_publisher_mqtt/mqtt.py
+++ b/front/plugins/_publisher_mqtt/mqtt.py
@@ -364,7 +364,7 @@ def mqtt_start(db):
             
             # Create devices in Home Assistant - send config messages
             deviceId        = 'mac_' + device["dev_MAC"].replace(" ", "").replace(":", "_").lower()
-            devDisplayName  = re.sub('[^a-zA-Z0-9-_\s]', '', device["dev_Name"]) 
+            devDisplayName  = re.sub('[^a-zA-Z0-9-_\\s]', '', device["dev_Name"]) 
 
             sensorConfig = create_sensor(mqtt_client, deviceId, devDisplayName, 'sensor', 'last_ip', 'ip-network', device["dev_MAC"])
             sensorConfig = create_sensor(mqtt_client, deviceId, devDisplayName, 'sensor', 'mac_address', 'folder-key-network', device["dev_MAC"])


### PR DESCRIPTION
`\s` is invalid in Python3 and must be `\\s` now

12:37:02 [Plugin utils] ---------------------------------------------
12:37:02 [Plugin utils] display_name: MQTT publisher
12:37:02 [Plugins] Executing: python3 /app/front/plugins/_publisher_mqtt/mqtt.py devices={devices}
12:37:03 /app/front/plugins/_publisher_mqtt/mqtt.py:362: SyntaxWarning: invalid escape sequence '\s'
  devDisplayName  = re.sub('[^a-zA-Z0-9-_\s]', '', device["dev_Name"]) 
Traceback (most recent call last):
  File "/app/front/plugins/_publisher_mqtt/mqtt.py", line 26, in <module>
    from plugin_utils import getPluginObject