### PR TITLE
Fix for MQTT device tracker adding quotes to payload

### DIFF
--- a/front/plugins/_publisher_mqtt/mqtt.py
+++ b/front/plugins/_publisher_mqtt/mqtt.py
@@ -196,7 +196,10 @@ class sensor_config:
 def publish_mqtt(mqtt_client, topic, message):
     status = 1
 
-    message = json.dumps(message).replace("'",'"')
+    # convert anything but a simple string to json
+    if not isinstance(message, str):
+        message = json.dumps(message).replace("'",'"')
+
     qos = get_setting_value('MQTT_QOS')
 
     mylog('verbose', [f"[{pluginName}] Sending MQTT topic: {topic}"])


### PR DESCRIPTION
Ref issue https://github.com/jokob-sk/NetAlertX/issues/702

`json_dumps` adds quotations to the string:

```
>>> import json
>>> json.dumps("home")
'"home"'
>>>
```

So we either need to stick to json only or check the instance and if the instance is just a string, then do not do any `json_dumps`.
