### PR TITLE
Fixes to work using a reverse proxy

### DIFF
--- a/front/appEventsCore.php
+++ b/front/appEventsCore.php
@@ -17,7 +17,7 @@ showSpinner()
 $(document).ready(function() {
 
     // Load JSON data from the provided URL
-    $.getJSON('/api/table_appevents.json', function(data) {
+    $.getJSON('api/table_appevents.json', function(data) {
         // Process the JSON data and generate UI dynamically        
         processData(data)
 

--- a/front/report.php
+++ b/front/report.php
@@ -99,7 +99,7 @@
     // Function to update the displayed data and timestamp based on the selected format and index
     function updateData(format, index) {
         // Fetch data from the API endpoint
-        fetch('/api/table_notifications.json?nocache=' + Date.now())
+        fetch('api/table_notifications.json?nocache=' + Date.now())
             .then(response => response.json())
             .then(data => {
                 if (index < 0) {
@@ -163,7 +163,7 @@
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has('guid')) {
         const guid = urlParams.get('guid');
-        fetch('/api/table_notifications.json')
+        fetch('api/table_notifications.json')
             .then(response => response.json())
             .then(data => {
                 const index = findIndexByGUID(data.data, guid);

--- a/front/userNotifications.php
+++ b/front/userNotifications.php
@@ -60,7 +60,7 @@ require 'php/templates/header.php';
 <script>
   function fetchData(callback) {
     $.ajax({
-      url: '/api/user_notifications.json?nocache=' + Date.now(),
+      url: 'api/user_notifications.json?nocache=' + Date.now(),
       method: 'GET',
       dataType: 'json',
       success: function(response) {


### PR DESCRIPTION
When using a reverse proxy with Subpath, the notifications don't load. The call is made to http://host/api/user_notifications.json instead of http://host/netalertx/api/user_notifications.json.
When I compared it to the [table_devices.json request](https://github.com/jokob-sk/NetAlertX/blob/30750a9449963d22a66b06aa129fa5b4ac59814e/front/devices.php#L403) (which works), I realized that it probably works there because it's relative. When I changed it manually on the server to test, the notifications appeared.

I don't think changing this should cause any problems, as table_devices.json already works like this. However, as everything in IT is strange, any small change can cause unexpected errors, so I suggest you test it too. :)

Not working:
![2024-09-22_21-11-19_firefox](https://github.com/user-attachments/assets/b4363c72-f963-4dcf-9964-6b7568ed51e4)

Working:
![2024-09-22_21-12-10_firefox](https://github.com/user-attachments/assets/f5903251-9881-42b1-8585-6a314203e2af)

Edit:
I saw some other requests that were giving the same problem, so I decided to look up everything that used '/api' and found these two more.

table_appevents.json
![2024-09-22_21-46-20_firefox](https://github.com/user-attachments/assets/8c6f5498-60bc-4b80-80ce-ade981ca2d17)
![2024-09-22_21-47-20_firefox](https://github.com/user-attachments/assets/00c599be-4cbb-4ce2-a418-16c790d9acb3)

table_notifications.json
![2024-09-22_21-48-41_firefox](https://github.com/user-attachments/assets/47fde345-99a8-4188-8c63-0c16ae125dd0)
![2024-09-22_21-49-42_firefox](https://github.com/user-attachments/assets/46ce8d91-c86a-4636-bbce-ce194d8a3270)
