### PR TITLE
Update MQTT to send model as device name

### DIFF
--- a/front/plugins/_publisher_mqtt/mqtt.py
+++ b/front/plugins/_publisher_mqtt/mqtt.py
@@ -92,7 +92,8 @@ class sensor_config:
         self.sensorType      = sensorType
         self.sensorName      = sensorName
         self.icon            = icon 
-        self.mac             = mac 
+        self.mac             = mac
+        self.model           = deviceName        
         self.state_topic     = ''
         self.json_attr_topic = ''
         self.topic           = ''
@@ -142,7 +143,8 @@ class sensor_config:
                                 "device": 
                                         { 
                                             "identifiers" : [self.deviceId+"_sensor", self.unique_id], 
-                                            "manufacturer" : "NetAlertX", 
+                                            "manufacturer" : "NetAlertX",
+                                            "model": self.model if self.model else "Unknown",
                                             "name" : self.deviceName
                                         }, 
                             }
@@ -430,6 +432,7 @@ def mqtt_start(db):
                         "is_new": str(device["dev_NewDevice"]), 
                         "vendor": sanitize_string(device["dev_Vendor"]), 
                         "mac_address": str(device["dev_MAC"]),
+                        "model": devDisplayName,
                         "last_connection": str(device["dev_LastConnection"]),
                         "first_connection": str(device["dev_FirstConnection"])
                     }


### PR DESCRIPTION
This change adds Model information for HomeAssistant that shows in Device info instead of showing Unknown. 

Users who previously had their devices discovered in HomeAssistant won't have this changed by default. Users need to delete their devices from HomeAssistant or [Force update MQTT for each device](https://github.com/jokob-sk/NetAlertX/blob/d1d6d7f1ec0372eccda7a8aba96fad3b7e1bed87/front/plugins/_publisher_mqtt/README.md). 

After change: 
![image](https://github.com/user-attachments/assets/26ea46da-1be1-4da9-bd70-b3177d9a05f4)
![image](https://github.com/user-attachments/assets/281b8fde-fc77-40ca-ac35-2d5cb39830b0)

