### PR TITLE
Rename MQTT topic - system-sensors to netalertx

### DIFF
--- a/front/plugins/_publisher_mqtt/README.md
+++ b/front/plugins/_publisher_mqtt/README.md
@@ -48,7 +48,7 @@ Payload:
 ```json
 {
   "name": "online",
-  "state_topic": "system-sensors/sensor/netalertx/state",
+  "state_topic": "netalertx/sensor/netalertx/state",
   "value_template": "{{value_json.online}}",
   "unique_id": "netalertx_sensor_online",
   "device": {
@@ -75,7 +75,7 @@ Payload:
 ```json
 {
   "name": "all",
-  "state_topic": "system-sensors/sensor/netalertx/state",
+  "state_topic": "netalertx/sensor/netalertx/state",
   "value_template": "{{value_json.all}}",
   "unique_id": "netalertx_sensor_all",
   "device": {
@@ -96,7 +96,7 @@ Payload:
 >[!NOTE]
 > You can replace the `netalertx` string of the below topic via the `DEVICE_ID` setting. 
 
-Topic: `system-sensors/sensor/netalertx/state`
+Topic: `netalertx/sensor/netalertx/state`
 
 Payload:
 
@@ -126,7 +126,7 @@ Payload:
 
 {
   "name": "last_ip",
-  "state_topic": "system-sensors/sensor/mac_44_ef_44_ef_44_ef/state",
+  "state_topic": "netalertx/sensor/mac_44_ef_44_ef_44_ef/state",
   "value_template": "{{value_json.last_ip}}",
   "unique_id": "mac_44_ef_44_ef_44_ef_sensor_last_ip",
   "device": {
@@ -144,7 +144,7 @@ Payload:
 
 ### MQTT state data:
 
-Topic: `system-sensors/sensor/mac_44_ef_44_ef_44_ef/state`
+Topic: `netalertx/sensor/mac_44_ef_44_ef_44_ef/state`
 
 Payload:
 
@@ -166,7 +166,7 @@ Payload:
 ```json
 {
   "name": "is_present",
-  "state_topic": "system-sensors/binary_sensor/mac_44_ef_44_ef_44_ef/state",
+  "state_topic": "netalertx/binary_sensor/mac_44_ef_44_ef_44_ef/state",
   "value_template": "{{value_json.is_present}}",
   "unique_id": "mac_44_ef_44_ef_44_ef_sensor_is_present",
   "device": {
@@ -181,7 +181,7 @@ Payload:
 }
 ```
 
-Topic: `system-sensors/binary_sensor/mac_44_ef_44_ef_44_ef/state`
+Topic: `netalertx/binary_sensor/mac_44_ef_44_ef_44_ef/state`
 
 Payload:
 

--- a/front/plugins/_publisher_mqtt/config.json
+++ b/front/plugins/_publisher_mqtt/config.json
@@ -656,7 +656,7 @@
       "description": [
         {
           "language_code": "en_us",
-          "string": "The root path of the stats overview sensor. Inserted into the <code>system-sensors/sensor/{DEVICE_ID}/state</code> topic."
+          "string": "The root path of the stats overview sensor. Inserted into the <code>netalertx/sensor/{DEVICE_ID}/state</code> topic."
         }
       ]
     },

--- a/front/plugins/_publisher_mqtt/mqtt.py
+++ b/front/plugins/_publisher_mqtt/mqtt.py
@@ -103,7 +103,7 @@ class sensor_config:
         if self.sensorType == 'binary_sensor' or self.sensorType == 'sensor':   
 
             self.topic          = f'homeassistant/{self.sensorType}/{self.deviceId}/{self.sensorName}/config'
-            self.state_topic    = f'system-sensors/{self.sensorType}/{self.deviceId}/state'
+            self.state_topic    = f'nextalertx/{self.sensorType}/{self.deviceId}/state'
             self.unique_id      = self.deviceId+'_sensor_'+self.sensorName            
 
             self.message = { 
@@ -124,8 +124,8 @@ class sensor_config:
         elif self.sensorType == 'device_tracker':
 
             self.topic           = f'homeassistant/device_tracker/{self.deviceId}/config'
-            self.state_topic     = f'system-sensors/device_tracker/{self.deviceId}/state'
-            self.json_attr_topic = f'system-sensors/device_tracker/{self.deviceId}/attributes'
+            self.state_topic     = f'nextalertx/device_tracker/{self.deviceId}/state'
+            self.json_attr_topic = f'nextalertx/device_tracker/{self.deviceId}/attributes'
             self.unique_id       = f'{self.deviceId}_{self.sensorType}_{self.sensorName}'
 
             payload_home = 'home'
@@ -383,7 +383,7 @@ def mqtt_start(db):
         row = get_device_stats(db)   
 
         # Publish (wrap into {} and remove last ',' from above)
-        publish_mqtt(mqtt_client, f"system-sensors/sensor/{deviceId}/state",              
+        publish_mqtt(mqtt_client, f"nextalertx/sensor/{deviceId}/state",              
                 { 
                     "online": row[0],
                     "down": row[1],


### PR DESCRIPTION
Hi, I'd like to rename the MQTT topic from `system-sensors` to `netalertx`. This makes it easier to distinguish in MQTT Explorer and also it aligns with other MQTT apps. such as Zigbee2MQTT who have their name shown there. (System-sensors sounds more like a system thing rather than something that came from netalertx :) ) 
Existing devices in HomeAssistant will be automatically mapped to the new topic without user interruption. 
The only downside is that the previous topic won't be removed from MQTT but this can easily be done in MQTT Explorer (in case someone wants to do this). The old topic `system-sensors` is automatically ignored by HomeAssistant. 

![image](https://github.com/user-attachments/assets/894462af-4a2b-4f89-a562-cbb9be3d1cfe)

No change done from my side, no need to delete devices or anything else. 
![image](https://github.com/user-attachments/assets/e3ffe999-ddb7-4a07-b30f-2e4a917b388b)

Could you please merge this change ? :)