### PR TITLE
Add events for imported devs

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -549,7 +549,8 @@ class DB():
                                 cur_SSID STRING(250),
                                 cur_NetworkNodeMAC STRING(250),
                                 cur_PORT STRING(250),
-                                cur_Type STRING(250)
+                                cur_Type STRING(250),
+                                UNIQUE(cur_MAC)
                             );
                         """)
 

--- a/server/device.py
+++ b/server/device.py
@@ -93,10 +93,7 @@ def save_scanned_devices (db):
 
     # Proceed if variable contains valid MAC
     if check_mac_or_internet(local_mac):
-        # Check if local mac has been detected with other methods
-        sql.execute (f"SELECT COUNT(*) FROM CurrentScan WHERE cur_MAC = '{local_mac}'")
-        if sql.fetchone()[0] == 0 :
-            sql.execute (f"""INSERT INTO CurrentScan (cur_MAC, cur_IP, cur_Vendor, cur_ScanMethod) VALUES ( '{local_mac}', '{local_ip}', Null, 'local_MAC') """)
+        sql.execute (f"""INSERT OR IGNORE INTO CurrentScan (cur_MAC, cur_IP, cur_Vendor, cur_ScanMethod) VALUES ( '{local_mac}', '{local_ip}', Null, 'local_MAC') """)
 
 #-------------------------------------------------------------------------------
 def print_scan_stats(db):

--- a/server/networkscan.py
+++ b/server/networkscan.py
@@ -206,10 +206,10 @@ def insert_events (db):
                                         END,
                                         '',
                                         1
-                        FROM LatestEventsPerMAC AS d 
-                        JOIN CurrentScan AS c ON d.dev_MAC = c.cur_MAC
+                        FROM CurrentScan AS c 
+                        LEFT JOIN LatestEventsPerMAC AS d ON d.dev_MAC = c.cur_MAC
                         LEFT JOIN LatestEventsPerMAC AS last_event ON d.dev_MAC = last_event.eve_MAC 
-                        WHERE d.dev_PresentLastScan = 0   
+                        WHERE d.dev_PresentLastScan = 0 OR d.dev_MAC IS NULL
                         """)
 
     # Check disconnections

--- a/server/networkscan.py
+++ b/server/networkscan.py
@@ -207,9 +207,8 @@ def insert_events (db):
                                         '',
                                         1
                         FROM CurrentScan AS c 
-                        LEFT JOIN LatestEventsPerMAC AS d ON d.dev_MAC = c.cur_MAC
-                        LEFT JOIN LatestEventsPerMAC AS last_event ON d.dev_MAC = last_event.eve_MAC 
-                        WHERE d.dev_PresentLastScan = 0 OR d.dev_MAC IS NULL
+                        LEFT JOIN LatestEventsPerMAC AS last_event ON c.cur_MAC = last_event.eve_MAC 
+                        WHERE last_event.dev_PresentLastScan = 0 OR last_event.eve_MAC IS NULL
                         """)
 
     # Check disconnections

--- a/server/plugin.py
+++ b/server/plugin.py
@@ -747,7 +747,7 @@ def process_plugin_events(db, plugin, pluginsState, plugEventsArr):
             sqlParams.append(tuple(tmpList))
 
         # Generate the SQL INSERT query using the collected information.
-        q = f'INSERT into {dbTable} ({columnsStr}) VALUES ({valuesStr})'
+        q = f'INSERT OR IGNORE INTO {dbTable} ({columnsStr}) VALUES ({valuesStr})'
 
         # Log a debug message showing the generated SQL query for mapping.
         mylog('debug', ['[Plugins] SQL query for mapping: ', q])


### PR DESCRIPTION
When a scan detects a device is online but no initial connection event exists, this creates a connection event at scan time so the presence monitor can properly function.