### PR TITLE
Restore manual naming of static leases using comments for MTSCAN

### DIFF
--- a/front/plugins/mikrotik_scan/mikrotik.py
+++ b/front/plugins/mikrotik_scan/mikrotik.py
@@ -89,7 +89,7 @@ def get_entries(plugin_objects: Plugin_Objects) -> Plugin_Objects:
                     primaryId   = mac_address,
                     secondaryId = address,
                     watched1    = address,
-                    watched2    = host_name,
+                    watched2    = comment if comment else host_name,
                     watched3    = last_seen,
                     watched4    = '',
                     extra       = '',


### PR DESCRIPTION
It was removed as part of #759 (exactly: https://github.com/jokob-sk/NetAlertX/pull/759/files#diff-3141c3ddff99ee9cccc877150d8bd75a6a5227c3f049d6fe7809ef27b77cbb71L91 ), however comments are used to provide custom device names for Mikrotik's static leases

for example:
![image](https://github.com/user-attachments/assets/329f342a-fcfb-4630-a82c-098a3ab911d2)
