### PR TITLE
Restore manual naming of static leases using comments for MKSCAN + cleanups

### DIFF
--- a/front/plugins/mikrotik_scan/config.json
+++ b/front/plugins/mikrotik_scan/config.json
@@ -2,7 +2,7 @@
   "code_name": "mikrotik_scan",
   "unique_prefix": "MTSCAN",
   "plugin_type": "device_scanner",
-  "execution_order" : "Layer_4",
+  "execution_order" : "Layer_1",
   "enabled": true,
   "data_source": "script",
   "mapped_to_table": "CurrentScan",
@@ -27,12 +27,6 @@
     }
   ],
   "params": [
-    {
-      "name": "ips",
-      "type": "sql",
-      "value": "SELECT devLastIP from DEVICES order by devMac",
-      "timeoutMultiplier": true
-    },
     {
       "name": "mt_host",
       "type": "setting",

--- a/front/plugins/mikrotik_scan/mikrotik.py
+++ b/front/plugins/mikrotik_scan/mikrotik.py
@@ -1,27 +1,16 @@
 #!/usr/bin/env python
 
 import os
-import pathlib
-import argparse
-import subprocess
 import sys
-import hashlib
-import csv
-import sqlite3
-import re
-from io import StringIO
-from datetime import datetime
 
 # Register NetAlertX directories
 INSTALL_PATH="/app"
 sys.path.extend([f"{INSTALL_PATH}/front/plugins", f"{INSTALL_PATH}/server"])
 
-from plugin_helper import Plugin_Object, Plugin_Objects, decodeBase64
-from logger import mylog, Logger, append_line_to_file
-from helper import timeNowTZ, get_setting_value
-from const import logPath, applicationPath, fullDbPath
-from database import DB
-from device import Device_obj
+from plugin_helper import Plugin_Objects
+from logger import mylog, Logger
+from helper import get_setting_value
+from const import logPath
 import conf
 from pytz import timezone
 from librouteros import connect
@@ -81,6 +70,7 @@ def get_entries(plugin_objects: Plugin_Objects) -> Plugin_Objects:
             comment = lease.get('comment')
             last_seen = lease.get('last-seen')
             status = lease.get('status')
+            device_name = comment or host_name or "(unknown)"
     
             mylog('verbose', [f"ID: {lease_id}, Address: {address}, MAC Address: {mac_address}, Host Name: {host_name}, Comment: {comment}, Last Seen: {last_seen}, Status: {status}"])
 
@@ -89,9 +79,9 @@ def get_entries(plugin_objects: Plugin_Objects) -> Plugin_Objects:
                     primaryId   = mac_address,
                     secondaryId = address,
                     watched1    = address,
-                    watched2    = host_name,
-                    watched3    = last_seen,
-                    watched4    = '',
+                    watched2    = device_name,
+                    watched3    = host_name,
+                    watched4    = last_seen,
                     extra       = '',
                     helpVal1    = comment, 
                     foreignKey  = mac_address)


### PR DESCRIPTION
reopen of #938 
> It was removed as part of https://github.com/jokob-sk/NetAlertX/pull/759 (exactly: https://github.com/jokob-sk/NetAlertX/pull/759/files#diff-3141c3ddff99ee9cccc877150d8bd75a6a5227c3f049d6fe7809ef27b77cbb71L91 ), however comments are used to provide custom device names for Mikrotik's static leases

I have:
- removed unused imports and unused "ips" param, 
- created the device_name variable that tries to determine the name in order: comment>hostname>"(unknown)" fallback (so nslookup and other plugins can continue resolving from here)
- used all watchedValues that are defined in config.json