### PR TITLE
OMDSDNOPENAPI - Run command change due to plugin folder rename

### DIFF
--- a/front/plugins/omada_sdn_openapi/config.json
+++ b/front/plugins/omada_sdn_openapi/config.json
@@ -331,7 +331,7 @@
           }
         ]
       },
-      "default_value": "python3 /app/front/plugins/omada_sdn_openapi_import/script.py",
+      "default_value": "python3 /app/front/plugins/omada_sdn_openapi/script.py",
       "options": [],
       "localized": ["name", "description"],
       "name": [


### PR DESCRIPTION
Since the plugin folder was renamed from `omada_sdn_openapi_import` to `omada_sdn_openapi` the `RUN` command should be changed as well for the plugin to work correctly.