### PR TITLE
Changing absolute path URL to relative path URL in devices.php

### DIFF
--- a/front/devices.php
+++ b/front/devices.php
@@ -218,7 +218,7 @@ function getDevicesTotals() {
 
         // Attempt to fetch data
         $.ajax({
-            url: '/php/server/query_json.php',
+            url: 'php/server/query_json.php',
             type: "GET",
             dataType: "json",
             data: {
@@ -336,7 +336,7 @@ let columnFilters = [];
 function initFilters() {
     // Attempt to fetch data
     $.ajax({
-        url: '/php/server/query_json.php',
+        url: 'php/server/query_json.php',
         type: "GET",
         dataType: "json",
         data: {
@@ -987,7 +987,7 @@ function handleLoadingDialog(needsReload = false)
 {
   // console.log(`needsReload: ${needsReload}`); 
 
-  $.get('/php/server/query_logs.php?file=execution_queue.log&nocache=' + Date.now(), function(data) {     
+  $.get('php/server/query_logs.php?file=execution_queue.log&nocache=' + Date.now(), function(data) {     
 
     if(data.includes("update_api|devices"))
     {       


### PR DESCRIPTION
Hi @jokob-sk,

<h1>Pull Request</h1>
<h2>Description</h2>

Changed the absolute path URL to relative path URL in devices.php, this is a fix for issues with reverse proxy servers.

<h2>Changes</h2>

<h3>Update devices.php (/front/devices.php)</h3>

Changed three absolute path URLs to relative path URLs

<h2>Test</h2>

Tested locally and works fine