### PR TITLE
Update manager.py

### DIFF
--- a/server/workflows/manager.py
+++ b/server/workflows/manager.py
@@ -50,7 +50,8 @@ class WorkflowManager:
     def process_event(self, event):
         """Process the events. Check if events match a workflow trigger"""
         
-        mylog('verbose', [f"[WF] Processing event with GUID {event["GUID"]}"])
+        guid = event["GUID"]
+        mylog('verbose', [f"[WF] Processing event with GUID {guid}"])
 
         # Check if the trigger conditions match
         for workflow in self.workflows:


### PR DESCRIPTION
This PR fixes a syntax error in an f-string caused by using double quotes inside another pair of double quotes. In Python, f-strings do not allow unescaped nested double quotes.

Before (invalid syntax):

`f"[WF] Processing event with GUID {event["GUID"]}"
`
After (valid syntax):

`f'[WF] Processing event with GUID {event["GUID"]}'
`
Alternatively, we could escape the inner quotes or assign the value to a variable before formatting. This change ensures the code runs correctly across all Python versions.