### PR TITLE
properly indent HTML tables in report emails to fix broken links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . ${INSTALL_DIR}/
 
-RUN pip install openwrt-luci-rpc asusrouter asyncio aiohttp graphene flask tplink-omada-client wakeonlan pycryptodome requests paho-mqtt scapy cron-converter pytz json2table dhcp-leases pyunifi speedtest-cli chardet python-nmap dnspython librouteros git+https://github.com/foreign-sub/aiofreepybox.git \
+RUN pip install openwrt-luci-rpc asusrouter asyncio aiohttp graphene flask tplink-omada-client wakeonlan pycryptodome requests paho-mqtt scapy cron-converter pytz json2table dhcp-leases pyunifi speedtest-cli chardet python-nmap dnspython librouteros yattag git+https://github.com/foreign-sub/aiofreepybox.git \
     && bash -c "find ${INSTALL_DIR} -type d -exec chmod 750 {} \;" \
     && bash -c "find ${INSTALL_DIR} -type f -exec chmod 640 {} \;" \
     && bash -c "find ${INSTALL_DIR} -type f \( -name '*.sh' -o -name '*.py'  -o -name 'speedtest-cli' \) -exec chmod 750 {} \;"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -43,7 +43,7 @@ RUN phpenmod -v 8.2 sqlite3
 RUN apt-get install -y python3-venv
 RUN python3 -m venv myenv
 
-RUN /bin/bash -c "source myenv/bin/activate && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && pip3 install openwrt-luci-rpc asusrouter asyncio aiohttp graphene flask tplink-omada-client wakeonlan pycryptodome requests paho-mqtt scapy cron-converter pytz json2table dhcp-leases pyunifi speedtest-cli chardet python-nmap dnspython librouteros "
+RUN /bin/bash -c "source myenv/bin/activate && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && pip3 install openwrt-luci-rpc asusrouter asyncio aiohttp graphene flask tplink-omada-client wakeonlan pycryptodome requests paho-mqtt scapy cron-converter pytz json2table dhcp-leases pyunifi speedtest-cli chardet python-nmap dnspython librouteros yattag "
 
 # Create a buildtimestamp.txt to later check if a new version was released
 RUN date +%s > ${INSTALL_DIR}/front/buildtimestamp.txt

--- a/server/notification.py
+++ b/server/notification.py
@@ -6,6 +6,7 @@ import uuid
 import socket
 import subprocess
 import requests
+from yattag import indent
 from json2table import convert
 
 # Register NetAlertX modules 
@@ -172,9 +173,16 @@ class Notification_obj:
             final_text = removeDuplicateNewLines(mail_text)
 
             # Create clickable MAC links            
-            final_html = generate_mac_links (mail_html, conf.REPORT_DASHBOARD_URL + '/deviceDetails.php?mac=')    
+            mail_html = generate_mac_links (mail_html, conf.REPORT_DASHBOARD_URL + '/deviceDetails.php?mac=')
 
-            send_api(self.JSON, mail_text, mail_html)
+            final_html = indent(
+                mail_html,
+                indentation = '    ',
+                newline = '\r\n',
+                indent_text = True
+            )
+
+            send_api(self.JSON, final_text, final_html)
 
             #  Write output data for debug            
             write_file (logPath + '/report_output.txt', final_text)


### PR DESCRIPTION
As SMTP defines a limit of 1000 characters per line, sane MTA add a newline to not break the SMTP standard.
Unfortunately those stupid little MTAs don't know anything about HTML, and just add the line break whereever they see fit... even if that's in the middle of a link, which then breaks the link.

By properly indenting the HTML that's generated, we're keeping those stupid MTAs from messing without our precious HTML, ensuring that all links are still working.

See https://github.com/jokob-sk/NetAlertX/issues/1049 