### PR TITLE
use relative paths for reverse proxy

### DIFF
--- a/front/js/handle_version.js
+++ b/front/js/handle_version.js
@@ -33,7 +33,7 @@ function versionUpdateUI(){
 // Checks if a new version is available via the global app_state.json
 function checkIfNewVersionAvailable()
 {
-  $.get('/php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {   
+  $.get('php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {   
     
     // console.log(appState["isNewVersionChecked"])
     // console.log(appState["isNewVersion"])

--- a/front/php/components/graph_online_history.php
+++ b/front/php/components/graph_online_history.php
@@ -18,7 +18,7 @@
 
 
 function initOnlineHistoryGraph() {
-    $.get('/php/server/query_json.php', { file: 'table_online_history.json', nocache: Date.now() }, function(res) {
+    $.get('php/server/query_json.php', { file: 'table_online_history.json', nocache: Date.now() }, function(res) {
         // Extracting data from the JSON response
         var timeStamps = [];
         var onlineCounts = [];

--- a/front/php/templates/header.php
+++ b/front/php/templates/header.php
@@ -105,7 +105,7 @@
   // -------------------------------------------------------------
   // Updates the backend application state/status in the header
   function updateState(){
-    $.get('/php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {    
+    $.get('php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {    
 
       document.getElementById('state').innerHTML = appState["currentState"].replaceAll('"', '');
 

--- a/front/settings.php
+++ b/front/settings.php
@@ -206,7 +206,7 @@ $settingsJSON_DB = json_encode($settings, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX
                       }, 3000);
               } else
               {
-                $.get('/php/server/query_json.php', { file: 'plugins.json', nocache: Date.now() }, function(res) {
+                $.get('php/server/query_json.php', { file: 'plugins.json', nocache: Date.now() }, function(res) {
 
                   pluginsData = res["data"];  
 
@@ -550,7 +550,7 @@ $settingsJSON_DB = json_encode($settings, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX
 
       // collect values for each of the different input form controls
       // get settings to determine setting type to store values appropriately
-      $.get('/php/server/query_json.php', { file: 'table_settings.json', nocache: Date.now() }, function(res) { 
+      $.get('php/server/query_json.php', { file: 'table_settings.json', nocache: Date.now() }, function(res) { 
         // loop through the settings definitions from the json
         res["data"].forEach(set => {
 
@@ -740,7 +740,7 @@ $settingsJSON_DB = json_encode($settings, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX
     } else
     {
       // check if config file has been updated
-      $.get('/php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {   
+      $.get('php/server/query_json.php', { file: 'app_state.json', nocache: Date.now() }, function(appState) {   
 
         console.log("Settings: Got app_state.json");       
         


### PR DESCRIPTION
recent changes to the codebase use /php for get requests. This changes those to relative paths to allow for reverse proxy usage.