### PR TITLE
Update freebox.py: add missing entries in device_type_map

### DIFF
--- a/front/plugins/freebox/freebox.py
+++ b/front/plugins/freebox/freebox.py
@@ -77,8 +77,12 @@ device_type_map = {
 
 
 def map_device_type(type: str):
-    return device_type_map[type]
-
+    try:
+        return device_type_map[type]
+    except KeyError:
+        # This device type has not been mapped yet
+        mylog("minimal", [f"[{pluginName}] Unknown device type: {type}"])
+        return device_type_map["other"]
 
 async def get_device_data(api_version: int, api_address: str, api_port: int):
     # ensure existence of db path

--- a/front/plugins/freebox/freebox.py
+++ b/front/plugins/freebox/freebox.py
@@ -66,6 +66,12 @@ device_type_map = {
     "networking_device": "Router",
     "multimedia_device": "TV Decoder",
     "car": "House Appliance",
+    "watch": "Clock",
+    "light": "Domotic",
+    "outlet": "Domotic",
+    "appliances": "House Appliance",
+    "thermostat": "Domotic",
+    "shutter": "Domotic",
     "other": "(Unknown)",
 }
 


### PR DESCRIPTION
New entries extracted from latest Freebox Server web interface
If a new device type has not been mapped yet, do not fail the scan but return "Unknown" instead (for future types)

Fix #1084 