### PR TITLE
Sanitize device fields and prevent crash with numeric hostnames

### DIFF
--- a/server/scan/device_handling.py
+++ b/server/scan/device_handling.py
@@ -732,8 +732,8 @@ def guess_icon(vendor, mac, ip, name,  default):
 # Guess device type
 def guess_type(vendor, mac, ip, name,  default):
     result = default
-    mac    = mac.upper()
-    vendor = vendor.lower() if vendor else "unknown"
+    mac    = str(mac).upper() if mac else "00:00:00:00:00:00"
+    vendor = str(vendor).lower() if vendor else "unknown"
     name   = str(name).lower() if name else "(unknown)"
 
     # Guess icon based on vendor


### PR DESCRIPTION
This patch improves the resilience of the guess_icon function by sanitizing mac, vendor, and name fields to avoid crashes caused by unexpected data types (e.g., numeric hostnames).

Specifically:

mac is now cast to a string before being uppercased, with a newly added fallback to "00:00:00:00:00:00" if empty or invalid.

vendor is sanitized to a string before lowercasing, still defaulting to "unknown".

name is cast to a string before lowercasing, still falling back to "(unknown)" when empty.

This change not only resolves the error caused by numeric-only hostnames (which triggered an AttributeError due to calling .lower() on an int), but also proactively prevents similar crashes from malformed or unexpected input in the future since I saw those other unsanitized calls for .lower() and .upper() sitting RIGHT THERE so I couldn't in good conscience just leave them there.

References: Fixes issue #1088 and also let's me sleep a little easier tonight.