### PR TITLE
Sanitize hostnames, macs, and vendor names before running .lower/.upper on them to prevent AttributeError

### DIFF
--- a/server/scan/device_handling.py
+++ b/server/scan/device_handling.py
@@ -674,9 +674,9 @@ def guess_icon(vendor, mac, ip, name,  default):
     mylog('debug', [f"[guess_icon] Guessing icon for (vendor|mac|ip|name): ('{vendor}'|'{mac}'|{ip}|{name})"])
     
     result = default
-    mac    = mac.upper()
-    vendor = vendor.lower() if vendor else "unknown"
-    name   = name.lower() if name else "(unknown)"
+    mac    = str(mac).upper() if mac else "00:00:00:00:00:00"
+    vendor = str(vendor).lower() if vendor else "unknown"
+    name   = str(name).lower() if name else "(unknown)"
 
     # Guess icon based on vendor
     if any(brand in vendor for brand in {"samsung", "motorola"}):
@@ -732,8 +732,8 @@ def guess_icon(vendor, mac, ip, name,  default):
 # Guess device type
 def guess_type(vendor, mac, ip, name,  default):
     result = default
-    mac    = mac.upper()
-    vendor = vendor.lower() if vendor else "unknown"
+    mac    = str(mac).upper() if mac else "00:00:00:00:00:00"
+    vendor = str(vendor).lower() if vendor else "unknown"
     name   = str(name).lower() if name else "(unknown)"
 
     # Guess icon based on vendor


### PR DESCRIPTION
Fixes #1088 by sanitizing the inputs to mac, vendor, and name before running .upper/.lower to ensure they are type STR to avoid AttributeError

Closes #1088