### PR TITLE
Add NetCreep as Alternatives 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Get notified about a new release, what new functionality you can use and about b
 - [WatchYourLAN](https://github.com/aceberg/WatchYourLAN) - Lightweight network IP scanner with web GUI (Open source)
 - [Fing](https://www.fing.com/) - Network scanner app for your Internet security (Commercial, Phone App, Proprietary hardware)
 - [NetBox](https://netboxlabs.com/) - Network management software (Commercial)
+- [NetCreep](https://github.com/CharlesLennon/NetCreep) - Network mapper 
 
 ### 💙 Donations
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Get notified about a new release, what new functionality you can use and about b
 - [WatchYourLAN](https://github.com/aceberg/WatchYourLAN) - Lightweight network IP scanner with web GUI (Open source)
 - [Fing](https://www.fing.com/) - Network scanner app for your Internet security (Commercial, Phone App, Proprietary hardware)
 - [NetBox](https://netboxlabs.com/) - Network management software (Commercial)
-- [NetCreep](https://github.com/CharlesLennon/NetCreep) - Network mapper 
+- [NetCreep](https://github.com/CharlesLennon/NetCreep) - Network mapper  (Open source)
 
 ### 💙 Donations
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "NetCreep" (Network mapper) to the list of alternative apps in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->