### PR TITLE
hotfix: invalid volume variable

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -69,7 +69,7 @@ services:
     network_mode: "host"        
     restart: unless-stopped
     volumes:
-      - ${APP_DATA_LOCATION}/netalertx/config:/app/config
+      - ${APP_CONFIG_LOCATION}/netalertx/config:/app/config
       - ${APP_DATA_LOCATION}/netalertx/db/:/app/db/      
       # (optional) useful for debugging if you have issues setting up the container
       - ${LOGS_LOCATION}:/app/log


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker Compose instructions to use the `${APP_CONFIG_LOCATION}` environment variable for the container configuration directory instead of `${APP_DATA_LOCATION}`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->