### PR TITLE
Changing absolute path URL to relative path URL in report.php

### DIFF
--- a/front/report.php
+++ b/front/report.php
@@ -86,7 +86,7 @@
     // Function to update the displayed data and timestamp based on the selected format and index
     function updateData(format, index) {
         // Fetch data from the API endpoint
-        fetch(`/php/server/query_json.php?file=table_notifications.json&nocache=${Date.now()}`)
+        fetch(`php/server/query_json.php?file=table_notifications.json&nocache=${Date.now()}`)
             .then(response => response.json())
             .then(data => {
                 if (index < 0) {


### PR DESCRIPTION
Hi @jokob-sk,

<h1>Pull Request</h1>
<h2>Description</h2>

Changed the absolute path URL to relative path URL in report.php, this is a fix for issues with reverse proxy servers.

<h2>Changes</h2>

<h3>Update report.php (/front/report.php)</h3>

URLs were changed from absolute paths to relative paths

<h2>Test</h2>

Tested locally and works fine


Change static route to relative route in URL for proper proxy operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where notifications data failed to load or refresh in some deployments due to an incorrect absolute path. Switched to a relative request, improving compatibility across environments (subdirectory installs, reverse proxies) and reducing intermittent 404/cache issues. Users should now see notifications populate and refresh consistently. No user action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->