### PR TITLE
Enhance in-app tooltips for clarity

### DIFF
--- a/front/plugins/sync/config.json
+++ b/front/plugins/sync/config.json
@@ -271,7 +271,7 @@
       "description": [
         {
           "language_code": "en_us",
-          "string": "The URL of the hub (target instance) with the targets <code>GRAPHQL_PORT</code> set as port. Set on the Node. Without a trailig slash, for example <code>http://192.168.1.82:20212</code>"
+          "string": "If specified, this node will push data to the <code>GRAPHQL_PORT</code> API of the target. Use the target device <code>GRAPHQL_PORT</code> URL Without a trailing slash, for example <code>http://192.168.1.82:20212</code>"
         }
       ]
     },
@@ -296,7 +296,7 @@
       "description": [
         {
           "language_code": "en_us",
-          "string": "Use a unique node name, without spaces or special characters, such as <code>Node_Vlan01</code>"
+          "string": "The unique name of this node, without spaces or special characters, such as <code>Node_Vlan01</code>"
         }
       ]
     },


### PR DESCRIPTION
While performing setup of `SYNC` I felt the descriptions were confusing. I ended up going to the documentation as the tips were confusing. This PR aims to improve clarity and remove my need to visit the docs in the future. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified sync configuration help text for the hub URL, including explicit guidance to use the target device’s GRAPHQL_PORT URL without a trailing slash and an illustrative example.
  * Corrected a typo (“trailig” → “trailing”).
  * Refined the description of the node name field to emphasize uniqueness and allowed characters.
  * These updates improve clarity for setup and reduce misconfiguration risk; no functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->