### PR TITLE
DB result iteration fix on empty result

### DIFF
--- a/server/db/db_helper.py
+++ b/server/db/db_helper.py
@@ -200,7 +200,9 @@ def get_table_json(sql, sql_query):
     except sqlite3.Error as e:
         mylog('verbose', ['[Database] - SQL ERROR: ', e])
         return json_obj({"data": []}, [])  # return empty object
-
+    except Exception as e:
+        mylog('verbose', ['[Database] - Unexpected ERROR: ', e])
+        return json_obj({"data": []}, [])
 
 #-------------------------------------------------------------------------------
 class json_obj:

--- a/server/db/db_helper.py
+++ b/server/db/db_helper.py
@@ -199,8 +199,12 @@ def get_table_json(sql, sql_query):
         mylog('verbose', ['[Database] - SQL ERROR: ', e])
         return json_obj({}, [])  # return empty object
 
-    result = {"data": [row_to_json(column_names, row) for row in rows]}
-    return json_obj(result, column_names)
+    if (rows):
+        result = {"data": [row_to_json(column_names, row) for row in rows]}
+        return json_obj(result, column_names)
+    else:
+        # the SQL query returned no rows
+        return json_obj({}, [])  # return empty object
 
 
 #-------------------------------------------------------------------------------

--- a/server/db/db_helper.py
+++ b/server/db/db_helper.py
@@ -203,8 +203,8 @@ def get_table_json(sql, sql_query):
         result = {"data": [row_to_json(column_names, row) for row in rows]}
         return json_obj(result, column_names)
     else:
-        # the SQL query returned no rows
-        return json_obj({}, [])  # return empty object
+        result = {"data": []}
+        return json_obj(result, column_names)
 
 
 #-------------------------------------------------------------------------------

--- a/server/db/db_helper.py
+++ b/server/db/db_helper.py
@@ -6,7 +6,8 @@ INSTALL_PATH="/app"
 sys.path.extend([f"{INSTALL_PATH}/server"])
 
 from helper import if_byte_then_to_str
-from logger import mylog  
+from logger import mylog
+
 
 #-------------------------------------------------------------------------------
 #  Return the SQL WHERE clause for filtering devices based on their status.
@@ -41,7 +42,6 @@ def get_device_condition_by_status(device_status):
     return conditions.get(device_status, 'WHERE 1=0')
 
 
-
 #-------------------------------------------------------------------------------
 #  Creates a JSON-like dictionary from a database row
 def row_to_json(names, row):
@@ -70,6 +70,7 @@ def row_to_json(names, row):
         rowEntry[name] = if_byte_then_to_str(row[name])
 
     return rowEntry
+
 
 #-------------------------------------------------------------------------------
 def sanitize_SQL_input(val):
@@ -114,7 +115,6 @@ def get_date_from_period(period):
     period_sql = f"date('now', '-{days} day')"
 
     return period_sql
-
 
 
 #-------------------------------------------------------------------------------
@@ -195,16 +195,11 @@ def get_table_json(sql, sql_query):
         sql.execute(sql_query)
         column_names = [col[0] for col in sql.description]
         rows = sql.fetchall()
+        data = [row_to_json(column_names, row) for row in rows] if rows else []
+        return json_obj({"data": data}, column_names if rows else [])
     except sqlite3.Error as e:
         mylog('verbose', ['[Database] - SQL ERROR: ', e])
-        return json_obj({}, [])  # return empty object
-
-    if (rows):
-        result = {"data": [row_to_json(column_names, row) for row in rows]}
-        return json_obj(result, column_names)
-    else:
-        result = {"data": []}
-        return json_obj(result, column_names)
+        return json_obj({"data": []}, [])  # return empty object
 
 
 #-------------------------------------------------------------------------------

--- a/server/db/db_helper.py
+++ b/server/db/db_helper.py
@@ -193,16 +193,21 @@ def get_table_json(sql, sql_query):
     """
     try:
         sql.execute(sql_query)
-        column_names = [col[0] for col in sql.description]
         rows = sql.fetchall()
-        data = [row_to_json(column_names, row) for row in rows] if rows else []
-        return json_obj({"data": data}, column_names if rows else [])
+        if (rows):
+            # We only return data if we actually got some out of SQLite
+            column_names = [col[0] for col in sql.description]
+            data = [row_to_json(column_names, row) for row in rows]
+            return json_obj({"data": data}, column_names)
     except sqlite3.Error as e:
+        # SQLite error, e.g. malformed query
         mylog('verbose', ['[Database] - SQL ERROR: ', e])
-        return json_obj({"data": []}, [])  # return empty object
     except Exception as e:
+        # Catch-all for other exceptions, e.g. iteration error
         mylog('verbose', ['[Database] - Unexpected ERROR: ', e])
-        return json_obj({"data": []}, [])
+        
+    # In case of any error or no data, return empty object
+    return json_obj({"data": []}, [])
 
 #-------------------------------------------------------------------------------
 class json_obj:


### PR DESCRIPTION
get_table_json would throw exceptions when trying to iterate over a NONE result, ie SQL query returned empty result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent empty-state returned for no-row queries and on database or unexpected errors: responses now include an explicit empty data payload and no column names.
  * Non-empty query results continue to return full data as before.
* **Chores**
  * Minor import/formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->