### PR TITLE
provide more descriptive reason for failure

### DIFF
--- a/front/php/templates/security.php
+++ b/front/php/templates/security.php
@@ -48,7 +48,7 @@ if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'logout') {
 
 // Load configuration
 if (!file_exists(CONFIG_PATH)) {
-    die("Configuration file not found.");
+    die("Configuration file not found in " . $_SERVER['DOCUMENT_ROOT'] . "/../config/app.conf");
 }
 $configLines = file(CONFIG_PATH);
 


### PR DESCRIPTION
The original message states the configuration file was not found.  This provides a bit more context as to where it was not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the missing configuration error message to display the expected file path, providing clearer guidance for troubleshooting.
  * Behavior remains unchanged: the application stops if the configuration is absent, but users now see the full path derived from the server’s document root to help identify and resolve the issue more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->