### PR TITLE
Make it easier to find the corresponding log files

### DIFF
--- a/front/php/components/logs.php
+++ b/front/php/components/logs.php
@@ -62,7 +62,7 @@ function renderLogArea($params) {
                 '</textarea>
             </div>
             <div class="row logs-row">
-                <div class="log-file col-sm-6 col-xs-12">' . htmlspecialchars($fileName) . '
+                <div class="log-file col-sm-6 col-xs-12">' . htmlspecialchars($filePath) . '
                     <div class="logs-size">' . number_format((filesize($filePath) / 1000000), 2, ",", ".") . ' MB'
                     . $downloadButtonHtml .
                     '</div>


### PR DESCRIPTION
This is a simple change to include the full path to the file.  I actually needed to debug to figure out why /app/log/nginx/error.log wasn't populating.  Not all the logs are in the same folder so it makes sense to specify location for each.
<img width="889" height="511" alt="image" src="https://github.com/user-attachments/assets/9bc169b9-2cf7-4afe-a696-955f80f5bb0a" />
