### PR TITLE
Change default encryption key to an empty string

### DIFF
--- a/front/php/server/db.php
+++ b/front/php/server/db.php
@@ -82,7 +82,7 @@ class CustomDatabaseWrapper {
     private $maxRetries;
     private $retryDelay;
 
-    public function __construct($filename, $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $maxRetries = 3, $retryDelay = 1000, $encryptionKey = null) {
+    public function __construct($filename, $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $maxRetries = 3, $retryDelay = 1000, $encryptionKey = "") {
         $this->sqlite = new SQLite3($filename, $flags, $encryptionKey);
         $this->maxRetries = $maxRetries;
         $this->retryDelay = $retryDelay;


### PR DESCRIPTION
Php7.2 cryptography changed to not allow empty encryption strings.  A blank string is acceptable. though. 