### PR TITLE
Rework Logging in restart-backend.sh

### DIFF
--- a/.devcontainer/scripts/restart-backend.sh
+++ b/.devcontainer/scripts/restart-backend.sh
@@ -14,11 +14,11 @@ PORT_DEBUG=5678
 sudo killall python3 2>/dev/null || true
 sleep 2
 
+echo ''|tee -a $LOG_DIR/stdout.log $LOG_DIR/stderr.log $LOG_DIR/app.log
 
 cd "$APP_DIR"
 
 # Launch using absolute module path for clarity; rely on cwd for local imports
-setsid nohup ${PY} -m debugpy --listen 0.0.0.0:${PORT_DEBUG} /app/server/__main__.py >/dev/null 2>&1 &
+setsid nohup ${PY} -m debugpy --listen 0.0.0.0:${PORT_DEBUG} /app/server/__main__.py 1>>/app/log/stdout.log 2>>/app/log/stderr.log &
 PID=$!
 sleep 2
-

--- a/.devcontainer/scripts/restart-backend.sh
+++ b/.devcontainer/scripts/restart-backend.sh
@@ -19,6 +19,8 @@ echo ''|tee $LOG_DIR/stdout.log $LOG_DIR/stderr.log $LOG_DIR/app.log
 cd "$APP_DIR"
 
 # Launch using absolute module path for clarity; rely on cwd for local imports
-setsid nohup ${PY} -m debugpy --listen 0.0.0.0:${PORT_DEBUG} /app/server/__main__.py 1>>/app/log/stdout.log 2>>/app/log/stderr.log &
+setsid nohup "${PY}" -m debugpy --listen "0.0.0.0:${PORT_DEBUG}" /app/server/__main__.py \
+  1>>"$LOG_DIR/stdout.log" \
+  2>>"$LOG_DIR/stderr.log" &
 PID=$!
 sleep 2

--- a/.devcontainer/scripts/restart-backend.sh
+++ b/.devcontainer/scripts/restart-backend.sh
@@ -14,7 +14,7 @@ PORT_DEBUG=5678
 sudo killall python3 2>/dev/null || true
 sleep 2
 
-echo ''|tee -a $LOG_DIR/stdout.log $LOG_DIR/stderr.log $LOG_DIR/app.log
+echo ''|tee $LOG_DIR/stdout.log $LOG_DIR/stderr.log $LOG_DIR/app.log
 
 cd "$APP_DIR"
 


### PR DESCRIPTION
The stdout and stderr are useful logs when debugging and trying to figure out why plugin output is causing backend to stop and exception. This commit enables output redirection to `/app/stdout.log` and `/app/stderr.log` from the backend.  This may need backporting to production as it appears the fields are unused in the frontend log page. 

Additionally, when searching logs in the UI, the old logs appear first and your search results will invariably find old information when searching with ctrl-f-"string"-enter. So upon backend start and to keep them relevant, the stdout, stderr, and app logs are cleared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved backend startup logging: stdout, stderr, and application logs are now written to dedicated files for better visibility during development and container runs.
  - Added an initial log entry to ensure log files are created/truncated before the service starts.

- **Style**
  - Minor formatting and quoting cleanup to improve readability without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->