### PR TITLE
make scheduler setup more robust against wrong scheduling

### DIFF
--- a/server/initialise.py
+++ b/server/initialise.py
@@ -368,8 +368,19 @@ def importConfigs (pm, db, all_plugins):
         # mylog('verbose', [f"[Config] pref {plugin["unique_prefix"]} run_val {run_val} run_sch {run_sch} "])
 
         if run_val == 'schedule':
-            newSchedule = Cron(run_sch).schedule(start_date=datetime.datetime.now(conf.tz))
-            conf.mySchedules.append(schedule_class(plugin["unique_prefix"], newSchedule, newSchedule.next(), False))
+            newSchedule = None
+            try:
+                newSchedule = Cron(run_sch).schedule(start_date=datetime.datetime.now(conf.tz))
+                if (newSchedule is not None):
+                    conf.mySchedules.append(schedule_class(plugin["unique_prefix"], newSchedule, newSchedule.next(), False))
+                else:
+                    raise(ValueError("Invalid schedule"))
+            except ValueError as e:
+                mylog('none', [f"[Config] [ERROR] Invalid schedule '{run_sch}' for plugin '{plugin['unique_prefix']}'. Error: {e}."])
+            except Exception as e:
+                mylog('none', [f"[Config] [ERROR] Could not set schedule '{run_sch}' for plugin '{plugin['unique_prefix']}'. Error: {e}."])
+
+    
 
     # mylog('verbose', [f"[Config] conf.mySchedules {conf.mySchedules}"])
 


### PR DESCRIPTION
Ref: Issue https://github.com/jokob-sk/NetAlertX/issues/1199

If the schedule input is incorrect, an error message is logged and the plugin will NOT run. Creating a dummy schedule would throw the system out of balance as there's the danger of schedules running out of sync.

Error message in log:
`16:57:20 ["[Config] [ERROR] Invalid schedule '*/2 * * * 5* *' for plugin 'INTRNT'. Error: Invalid cron string format."]`

The settings screen will also show a warning:
<img width="1107" height="336" alt="image" src="https://github.com/user-attachments/assets/87c3f85e-637a-4434-81ff-65b881f93113" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability for scheduled runs by validating cron expressions before applying them.
  - Prevents invalid or empty schedules from being added, reducing runtime errors.
  - Provides clearer error messages when schedule configuration is invalid.
  - Adds safeguards to log unexpected issues during schedule setup, improving diagnosability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->