### PR TITLE
Fix install script references in HW_INSTALL.md

### DIFF
--- a/docs/HW_INSTALL.md
+++ b/docs/HW_INSTALL.md
@@ -65,11 +65,11 @@ wget https://raw.githubusercontent.com/jokob-sk/NetAlertX/main/install/debian12/
 
 ### Installation via curl
 ```bash
-curl -o install.ubuntu24.sh https://raw.githubusercontent.com/jokob-sk/NetAlertX/main/install/ubuntu24/install.ubuntu24.sh && sudo chmod +x install.ubuntu24.sh && sudo ./install.ubuntu24.sh
+curl -o install.sh https://raw.githubusercontent.com/jokob-sk/NetAlertX/main/install/ubuntu24/install.sh && sudo chmod +x install.sh && sudo ./install.sh
 ```
 
 ### Installation via wget
 
 ```bash
-wget https://raw.githubusercontent.com/jokob-sk/NetAlertX/main/install/ubuntu24/install.ubuntu24.sh -O install.ubuntu24.sh && sudo chmod +x install.ubuntu24.sh && sudo ./install.ubuntu24.sh
+wget https://raw.githubusercontent.com/jokob-sk/NetAlertX/main/install/ubuntu24/install.sh -O install.sh && sudo chmod +x install.sh && sudo ./install.sh
 ```


### PR DESCRIPTION
Fixing references to the Ubuntu install script , the install script in the doc references a install.ubuntu24.sh script when the script is actually located at install.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated installation guide to use a unified install.sh across both curl and wget methods.
  * Corrected download URLs, chmod command, and execution examples to match the new script name.
  * Removed outdated references to OS-specific script names for clarity.
  * Simplifies and standardizes the installation process for users following the guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->