### PR TITLE
Add an uninstall script for Ubuntu and fix the documentation

### DIFF
--- a/install/ubuntu24/uninstall.sh
+++ b/install/ubuntu24/uninstall.sh
@@ -197,12 +197,8 @@ echo "---------------------------------------------------------"
 PACKAGES_TO_PURGE=(
   git
   tini
-  ca-certificates
-  curl
   libwww-perl
   perl
-  apt-utils
-  cron
   build-essential
   sqlite3
   net-tools
@@ -216,7 +212,6 @@ PACKAGES_TO_PURGE=(
   snmp
   iproute2
   nmap
-  zip
   usbutils
   traceroute
   nbtscan


### PR DESCRIPTION
Add a script that uninstalls NetAlertX and update the documentation :

`mini@mini:~/netalertx$ sudo ./uninstall.sh 
---------------------------------------------------------
[UNINSTALL] Starting NetAlertX uninstallation for Ubuntu
---------------------------------------------------------

[UNINSTALL] Target install dir : /app
[UNINSTALL] Web UI location    : /var/www/html/netalertx
[UNINSTALL] Nginx config file  : /etc/nginx/conf.d/netalertx.conf
[UNINSTALL] Python venv        : /opt/netalertx-python

---------------------------------------------------------
[UNINSTALL] Stopping services
---------------------------------------------------------

---------------------------------------------------------
[UNINSTALL] Removing systemd unit and defaults
---------------------------------------------------------
[UNINSTALL] Systemd cleanup complete

---------------------------------------------------------
[UNINSTALL] Unmounting tmpfs mounts
---------------------------------------------------------
[UNINSTALL] Unmounted /app/log
[UNINSTALL] Unmounted /app/api

---------------------------------------------------------
[UNINSTALL] Cleaning nginx and web artifacts
---------------------------------------------------------
[UNINSTALL] Removed web UI link /var/www/html/netalertx
[UNINSTALL] Removed nginx config /etc/nginx/conf.d/netalertx.conf
[UNINSTALL] Re-enabled nginx default site

---------------------------------------------------------
[UNINSTALL] Removing application files
---------------------------------------------------------
[UNINSTALL] Removed virtual environment /opt/netalertx-python
[UNINSTALL] /app contains NetAlertX binaries, config, and database.
[UNINSTALL] Type 'purge' to delete it now, or press Enter to keep it:
  purge
[UNINSTALL] Removed /app

---------------------------------------------------------
[UNINSTALL] Reloading nginx
---------------------------------------------------------
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful

---------------------------------------------------------
[UNINSTALL] Package cleanup
---------------------------------------------------------
[UNINSTALL] The installer may have added these packages:
  - git
  - tini
  - ca-certificates
  - curl
  - libwww-perl
  - perl
  - apt-utils
  - cron
  - build-essential
  - sqlite3
  - net-tools
  - python3
  - python3-venv
  - python3-dev
  - python3-pip
  - dnsutils
  - mtr
  - arp-scan
  - snmp
  - iproute2
  - nmap
  - zip
  - usbutils
  - traceroute
  - nbtscan
  - avahi-daemon
  - avahi-utils
  - nginx-core
  - php8.3
  - php8.3-sqlite3
  - php
  - php-fpm
  - php-cgi
  - php8.3-fpm
  - php-sqlite3
  - php-curl
  - php-cli
[UNINSTALL] Removing them can affect other applications that rely on them.
[UNINSTALL] Type 'purge' to remove these packages now, or press Enter to keep them: purge
[UNINSTALL] Removing installer packages via apt-get purge.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 shim-signed : Depends: grub-efi-amd64-signed (>= 1.191~) but it is not going to be installed or
                        grub-efi-arm64-signed (>= 1.191~) but it is not installable or
                        base-files (< 12.3) but 13ubuntu10.3 is to be installed
               Depends: grub-efi-amd64-signed (>= 1.187.2~) but it is not going to be installed or
                        grub-efi-arm64-signed (>= 1.187.2~) but it is not installable
               Depends: grub2-common (>= 2.04-1ubuntu24) but it is not going to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
[UNINSTALL] Failed to purge some packages; please review the output above.

---------------------------------------------------------
[UNINSTALL] NetAlertX removal complete
---------------------------------------------------------
[UNINSTALL] Thank you for using NetAlertX.
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Ubuntu 24 uninstall script for NetAlertX.
  * Supports flags: --purge-data, --purge-packages, and --help.
  * Stops and disables the service, removes related configs, and reloads system services as needed.
  * Cleans web server configuration where applicable and safely reloads it.
  * Unmounts temporary mounts and removes application files, including virtual environments.
  * Offers interactive prompts and safeguards to prevent accidental data loss.
  * Optionally purges related packages for a thorough cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->