### PR TITLE
Update timestamp format to use UTC timezone

### DIFF
--- a/back/speedtest-cli
+++ b/back/speedtest-cli
@@ -957,7 +957,7 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
Remove deprecated API utilization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speed test results now use timezone-aware UTC timestamps, preserving the ISO 8601 format with a Z suffix.
  * Ensures consistent behavior across environments and avoids potential timezone-related discrepancies.
  * Improves interoperability with systems expecting strict ISO 8601/RFC 3339 compliance.
  * Reduces risk of parsing issues in downstream integrations, logs, and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->