### PR TITLE
Add script to regenerate the database from schema

### DIFF
--- a/scripts/db_cleanup/regenerate-database.sh
+++ b/scripts/db_cleanup/regenerate-database.sh
@@ -7,7 +7,7 @@ NETALERTX_DB_FILE=/app/db/app.db
 rm ${NETALERTX_DB_FILE}
 
 # Write schema to text to app.db file until we see "end-of-database-schema"
-cat << end-of-database-schema > ${NETALERTX_DB_FILE}
+cat << end-of-database-schema > ${NETALERTX_DB_FILE}.sql
 CREATE TABLE sqlite_stat1(tbl,idx,stat);
 CREATE TABLE Events (eve_MAC STRING (50) NOT NULL COLLATE NOCASE, eve_IP STRING (50) NOT NULL COLLATE NOCASE, eve_DateTime DATETIME NOT NULL, eve_EventType STRING (30) NOT NULL COLLATE NOCASE, eve_AdditionalInfo STRING (250) DEFAULT (''), eve_PendingAlertEmail BOOLEAN NOT NULL CHECK (eve_PendingAlertEmail IN (0, 1)) DEFAULT (1), eve_PairEventRowid INTEGER);
 CREATE TABLE Sessions (ses_MAC STRING (50) COLLATE NOCASE, ses_IP STRING (50) COLLATE NOCASE, ses_EventTypeConnection STRING (30) COLLATE NOCASE, ses_DateTimeConnection DATETIME, ses_EventTypeDisconnection STRING (30) COLLATE NOCASE, ses_DateTimeDisconnection DATETIME, ses_StillConnected BOOLEAN, ses_AdditionalInfo STRING (250));
@@ -422,4 +422,4 @@ CREATE TRIGGER "trg_delete_devices"
 end-of-database-schema
 
 # Import the database schema into the new database file
-sqlite3 ${NETALERTX_DB_FILE} < ${NETALERTX_DB}/db.sql
+sqlite3 ${NETALERTX_DB_FILE} < ${NETALERTX_DB_FILE}.sql


### PR DESCRIPTION
This script recreates the database from schema code and imports the schema into the new database file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a one-step database regeneration tool to recreate the SQLite database from the current schema for quick resets and consistent test environments.
* **Chores**
  * Provides a maintenance script to streamline database cleanup and rebuild, simplifying setup, recovery, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->