### PR TITLE
Fix typo in Baseline Docker Compose - DOCKER_COMPOSE.md

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -80,7 +80,7 @@ services:
       # /services/config/nginx/conf.d is required for nginx and php to start
       - "/services/run:uid=20211,gid=20211,mode=1700,rw,noexec,nosuid,nodev,async,noatime,nodiratime"
       # /tmp is required by php for session save this should be reworked to /services/run/tmp
-      - "/tmp:uid=2Key-Value Pairs: 20211,gid=20211,mode=1700,rw,noexec,nosuid,nodev,async,noatime,nodiratime"
+      - "/tmp:uid=20211,gid=20211,mode=1700,rw,noexec,nosuid,nodev,async,noatime,nodiratime"
     environment:
       LISTEN_ADDR: ${LISTEN_ADDR:-0.0.0.0}                   # Listen for connections on all interfaces
       PORT: ${PORT:-20211}                                   # Application port


### PR DESCRIPTION
Assuming this was a typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a mount configuration error that was preventing proper ownership and permission settings for the container's temporary storage directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->