### PR TITLE
Fix typo in warning message for read-only mode

### DIFF
--- a/install/production-filesystem/entrypoint.d/95-appliance-integrity.sh
+++ b/install/production-filesystem/entrypoint.d/95-appliance-integrity.sh
@@ -14,7 +14,7 @@ if ! awk '$2 == "/" && $4 ~ /ro/ {found=1} END {exit !found}' /proc/mounts; then
 ══════════════════════════════════════════════════════════════════════════════
 ⚠️  Warning: Container is running as read-write, not in read-only mode.
 
-    Please mount the root filesystem as --read-only or use read-only: true
+    Please mount the root filesystem as --read-only or use read_only: true
     https://github.com/jokob-sk/NetAlertX/blob/main/docs/docker-troubleshooting/read-only-filesystem.md
 ══════════════════════════════════════════════════════════════════════════════
 EOF


### PR DESCRIPTION
https://docs.docker.com/reference/compose-file/services/#read_only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected guidance text in filesystem warning message to reflect accurate configuration format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->