### PR TITLE
Add selenium to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -281,7 +281,7 @@ RUN chmod +x /entrypoint.sh /root-entrypoint.sh /entrypoint.d/*.sh && \
 
 RUN apk add --no-cache git nano vim jq php83-pecl-xdebug py3-pip nodejs sudo gpgconf pytest \
     pytest-cov zsh alpine-zsh-config shfmt github-cli py3-yaml py3-docker-py docker-cli docker-cli-buildx \
-    docker-cli-compose shellcheck py3-psutil 
+    docker-cli-compose shellcheck py3-psutil chromium chromium-chromedriver
 
 # Install hadolint (Dockerfile linter)
 RUN curl -L https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint && \
@@ -307,6 +307,6 @@ RUN mkdir -p /workspaces && \
     chown netalertx:netalertx /home/netalertx && \
     sed -i -e 's#/app:#/workspaces:#' /etc/passwd && \
     find /opt/venv -type d -exec chmod o+rwx {} \;
-    
+
 USER netalertx
 ENTRYPOINT ["/bin/sh","-c","sleep infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,7 @@
   },
 
   "postCreateCommand": {
-      "Install Pip Requirements": "/opt/venv/bin/pip3 install pytest docker debugpy",
+      "Install Pip Requirements": "/opt/venv/bin/pip3 install pytest docker debugpy selenium",
       "Workspace Instructions": "printf '\n\n� DevContainer Ready! Starting Services...\n\n📁 To access /tmp folders in the workspace:\n   File → Open Workspace from File → NetAlertX.code-workspace\n\n📖 See .devcontainer/WORKSPACE.md for details\n\n'"
   },
   "postStartCommand": {

--- a/.devcontainer/resources/devcontainer-Dockerfile
+++ b/.devcontainer/resources/devcontainer-Dockerfile
@@ -34,9 +34,6 @@ RUN apk add --no-cache git nano vim jq php83-pecl-xdebug py3-pip nodejs sudo gpg
 RUN curl -L https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint && \
     chmod +x /usr/local/bin/hadolint
 
-# Install Selenium for UI testing
-RUN python3 -m pip install --break-system-packages selenium
-
 RUN install -d -o netalertx -g netalertx -m 755 /services/php/modules && \
     cp -a /usr/lib/php83/modules/. /services/php/modules/ && \
     echo "${NETALERTX_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
This commit adds selenium to the post-create command.  Add chromium chromium-chromedriver to  devcontainer dockerfile.  This will enable unit tests which require browser automation in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development container with chromium and chromedriver for browser automation capabilities.
  * Updated development environment dependencies to include selenium for testing automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->