### PR TITLE
Add system pytest and use it instead

### DIFF
--- a/test/docker_tests/run_docker_tests.sh
+++ b/test/docker_tests/run_docker_tests.sh
@@ -35,6 +35,7 @@ docker run -d --name netalertx-test-container \
   --cap-add SYS_ADMIN \
   --cap-add NET_ADMIN \
   --cap-add NET_RAW \
+  --cap-add NET_BIND_SERVICE \
   --security-opt apparmor=unconfined \
   --add-host=host.docker.internal:host-gateway \
   -v /var/run/docker.sock:/var/run/docker.sock \
@@ -43,7 +44,7 @@ docker run -d --name netalertx-test-container \
 
 # --- 5. Install Python test dependencies ---
 echo "--- Installing Python test dependencies into venv ---"
-docker exec netalertx-test-container /opt/venv/bin/pip3 install --ignore-installed pytest docker debugpy selenium
+docker exec netalertx-test-container pip3 install --break-system-packages pytest docker debugpy selenium
 
 # --- 6. Execute Setup Script ---
 echo "--- Executing setup script inside the container ---"
@@ -76,7 +77,7 @@ docker exec netalertx-test-container /bin/bash -c " \
 # --- 9. Execute Tests ---
 echo "--- Executing tests inside the container ---"
 docker exec netalertx-test-container /bin/bash -c " \
-    cd /workspaces/NetAlertX && /opt/venv/bin/pytest -m 'not (docker or compose or feature_complete)' --cache-clear -o cache_dir=/tmp/.pytest_cache; \
+    cd /workspaces/NetAlertX && pytest -m 'not (docker or compose or feature_complete)' --cache-clear -o cache_dir=/tmp/.pytest_cache; \
 "
 
 # --- 10. Final Teardown ---


### PR DESCRIPTION
## 📌 Description

Fix failing unit tests in GitHub CI by installing `pytest` into the system environment inside the test container. The CI job spins up the container and uses the container's system Python (not the repository venv), so installing `pytest` system-wide ensures the test runner is available and the job behaves the same as the devcontainer.

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g., closes #123, fixes #456) -->

---

## 📋 Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix  
- [x] 🧪 Test addition or change  
- [x] 🔧 Build/config update  
- [x] 🔨 CI/CD or automation  
- [ ] ✨ New feature  
- [ ] ♻️ Code refactor  
- [ ] 📚 Documentation update  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Cleanup / chore

---

## 📷 Screenshots or Logs (if applicable)
See changes made in https://github.com/netalertx/NetAlertX/pull/1420

---

## 🧪 Testing Steps

- Push branch and allow GitHub Actions to run the docker-based test job.
- Verify the job installs `pytest` inside the container (e.g., `pip install pytest` runs in the job log).
- Verify `pytest` is invoked from the container system Python and that tests complete successfully.
- (Local verification) Build the test image and run a container, then inside it run `pip install pytest && pytest -q` to confirm behavior matches CI.

---

## ✅ Checklist

- [x] I have read the [Contribution Guidelines](../../CONTRIBUTING)  
- [x] I have tested my changes locally  
- [x] I have updated relevant documentation (if applicable)  
- [x] I have verified my changes do not break existing behavior  
- [x] I am willing to respond to requested changes and feedback

---

## 🙋 Additional Notes

This change mirrors the devcontainer testing environment and prevents CI from failing when `pytest` is not available on the container's system interpreter. Consider pinning the `pytest` version in a follow-up to avoid unexpected test runner upgrades.