### PR TITLE
php xdebug log location

### DIFF
--- a/.devcontainer/resources/devcontainer-overlay/services/config/php/conf.d/99-xdebug.ini
+++ b/.devcontainer/resources/devcontainer-overlay/services/config/php/conf.d/99-xdebug.ini
@@ -3,7 +3,7 @@ extension_dir="/services/php/modules"
 
 [xdebug]
 xdebug.mode=develop,debug
-xdebug.log=/app/log/xdebug.log
+xdebug.log=/tmp/log/xdebug.log
 xdebug.log_level=7
 xdebug.client_host=127.0.0.1
 xdebug.client_port=9003


### PR DESCRIPTION
## 📌 Description

Updates the Xdebug log path in the PHP configuration to use /tmp/log/ instead of /app/log/ to ensure proper write permissions within the container environment.

---

## 🔍 Related Issues

---

## 📋 Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Build/config update

---

## 📷 Screenshots or Logs (if applicable)

Was: xdebug.log=/app/log/xdebug.log
Is: xdebug.log=/tmp/log/xdebug.log

---

## 🧪 Testing Steps

1. Rebuild the devcontainer.
2. Trigger an Xdebug session.
3. Verify log creation at /tmp/log/xdebug.log.

---

## ✅ Checklist

- [x] I have read the [Contribution Guidelines](../../CONTRIBUTING)
- [x] I have tested my changes locally
- [x] I have updated relevant documentation (if applicable)
- [x] I have verified my changes do not break existing behavior
- [x] I am willing to respond to requested changes and feedback

---

## 🙋 Additional Notes

The /app/log directory was inappropriate; /tmp/log/ is the proper location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment logging configuration to use an alternative log file location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->