### PR TITLE
speed up devcontainer remove extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,8 +51,8 @@
       "Workspace Instructions": "printf '\n\n� DevContainer Ready! Starting Services...\n\n📁 To access /tmp folders in the workspace:\n   File → Open Workspace from File → NetAlertX.code-workspace\n\n📖 See .devcontainer/WORKSPACE.md for details\n\n'"
   },
   "postStartCommand": {
-      "Start Environment":"${containerWorkspaceFolder}/.devcontainer/scripts/setup.sh",
-      "Build test-container":"echo To speed up tests, building test container in background... && setsid docker buildx build -t netalertx-test . > /tmp/build.log 2>&1 && echo '🧪 Unit Test Docker image built: netalertx-test' &"
+      "Build test-container":"echo To speed up tests, building test container in background... && setsid docker buildx build -t netalertx-test . > /tmp/build.log 2>&1 && echo '🧪 Unit Test Docker image built: netalertx-test' &",
+      "Start Environment":"${containerWorkspaceFolder}/.devcontainer/scripts/setup.sh"
   },
   "customizations": {
     "vscode": {
@@ -63,7 +63,6 @@
         "bmewburn.vscode-intelephense-client",
         "xdebug.php-debug",
         "ms-python.vscode-pylance",
-        "pamaron.pytest-runner",
         "coderabbit.coderabbit-vscode",
         "ms-python.black-formatter",
         "jeff-hykin.better-dockerfile-syntax",


### PR DESCRIPTION
## 📌 Description

This PR reworks 2 devcontainer issues. 
1. The order of execution of building test container and initializing services is reversed to allow quicker access to services.
2. the pamaron.pytest-runner plugin was causing crashes and does not appear to be required.

---

## 🔍 Related Issues

---

## 📋 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] 🧪 Test addition or change
- [x] 🔧 Build/config update
- [ ] 🚀 Performance improvement
- [ ] 🔨 CI/CD or automation
- [x] 🧹 Cleanup / chore

---

## 📷 Screenshots or Logs (if applicable)

---

## 🧪 Testing Steps

1. Trigger a devcontainer rebuild.
2. Observe service availability timing.
3. Verify VS Code stability without the `pamaron.pytest-runner` extension.

---

## ✅ Checklist

- [x] I have read the [Contribution Guidelines](../../CONTRIBUTING)
- [x] I have tested my changes locally
- [x] I have updated relevant documentation (if applicable)
- [x] I have verified my changes do not break existing behavior
- [x] I am willing to respond to requested changes and feedback

---

## 🙋 Additional Notes

The `pamaron.pytest-runner` extension was identified as the primary source of workspace crashes. Testing confirms that native VS Code Python test discovery handles requirements sufficiently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development environment configuration and removed unnecessary development extensions to streamline the developer setup process.

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->