### PR TITLE
Enable proxies on docs

### DIFF
--- a/server/api_server/openapi/swagger.html
+++ b/server/api_server/openapi/swagger.html
@@ -16,7 +16,8 @@
   <script>
     window.onload = () => {
       window.ui = SwaggerUIBundle({
-        url: '/openapi.json',
+        // Use a relative path so the UI works whether served at /docs or /server/docs
+        url: 'openapi.json',
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
enables proxy on /docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API documentation loading to work correctly regardless of application hosting path configuration. The documentation now loads properly when accessed from different deployment locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->