### PR TITLE
Remove logging driver from Docker Compose config

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -81,7 +81,6 @@ services:
     cpu_shares: 512             # Relative CPU weight for CPU contention scenarios
     pids_limit: 512             # Limit the number of processes/threads to prevent fork bombs
     logging:
-      driver: "json-file"       # Use JSON file logging driver
       options:
         max-size: "10m"         # Rotate log files after they reach 10MB
         max-file: "3"           # Keep a maximum of 3 log files


### PR DESCRIPTION
Removed the line specifying json driver, thus allowing system defaults. Synology does not support json driver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Docker Compose logging configuration settings in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->