### PR TITLE
Add descriptive 403 for /server endpoint

### DIFF
--- a/front/403_internal.html
+++ b/front/403_internal.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access Restricted - NetAlertX</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #f8f9fa;
+            color: #212529;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            max-width: 600px;
+        }
+        h1 {
+            color: #dc3545;
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            margin-bottom: 1rem;
+            line-height: 1.5;
+        }
+        .code-snippet {
+            background-color: #e9ecef;
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-family: monospace;
+            font-weight: bold;
+        }
+        .footer {
+            margin-top: 2rem;
+            font-size: 0.9rem;
+            color: #6c757d;
+            border-top: 1px solid #dee2e6;
+            padding-top: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>403 Forbidden</h1>
+        <p>
+            The <span class="code-snippet">/server</span> endpoint is for <strong>internal use only</strong> and cannot be accessed from external browsers or applications.
+        </p>
+        <p>
+            This security measure protects the backend API. You will need to contact your system administrator in order to gain access to the API port (default: 20212), or use the application through the standard web interface.
+        </p>
+        <div class="footer">
+            NetAlertX Security &bull; Trust Level: Untrusted Origin
+        </div>
+    </div>
+</body>
+</html>

--- a/install/production-filesystem/services/config/nginx/netalertx.conf.template
+++ b/install/production-filesystem/services/config/nginx/netalertx.conf.template
@@ -117,6 +117,7 @@ http {
 
         location /server/ {
             # 1. Enforcement
+            error_page 403 /403_internal.html;
             if ($is_trusted != "TRUSTED") {
                 return 403;
             }


### PR DESCRIPTION
A new 403 page describes the issue faced in #1496, which is intended operation.  However, the previous standard Nginx 403 message was too generic and did not give the user any further information about how to proceed when faced with a 403 from the internal `/server` proxy.  This 403 page should fix that problem.
<img width="704" height="375" alt="image" src="https://github.com/user-attachments/assets/ed3dbc90-1842-4a8a-898b-4e0f727b12b6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a custom 403 Forbidden error page for internal-only endpoints. The page features branded styling and responsive design, clearly communicates that access is restricted, explains the endpoint is for internal use only, blocks external origins, and provides guidance directing users to contact an administrator or access via the standard web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->