### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/front/lib/datatables/datatables.js
+++ b/front/lib/datatables/datatables.js
@@ -9059,6 +9059,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
## Summary
**CVE-2015-9251** — jQuery `ajax` improperly executes cross-domain responses inferred as `script` when `dataType` was not explicit.

## File
`front/lib/datatables/datatables.js` (bundled jQuery / DataTables).

## Changes
- In `ajaxConvert`, add upstream **gh-2432** mitigation (`continue` when `s.crossDomain && current === "script"`) before seeking converters.

## Impact
Matches security intent of [jquery/jquery@2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49).

## References
- CVE-2015-9251
- https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where AJAX requests with cross-domain origins were incorrectly processing script-type responses through the data converter pipeline, which could lead to unexpected behavior. The application now correctly skips converter processing for script data types in cross-domain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->