### PR TITLE
Fix timezone handling in format_date_iso: ensure fallback to UTC for …

### DIFF
--- a/server/utils/datetime_utils.py
+++ b/server/utils/datetime_utils.py
@@ -6,7 +6,7 @@ import datetime
 import re
 import pytz
 from typing import Union, Optional
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import email.utils
 import conf
 # from const import *
@@ -214,7 +214,7 @@ def format_date_iso(date_val: str) -> Optional[str]:
             # Resolve target timezone; fall back to UTC if conf.tz is missing/invalid
             try:
                 target_tz = conf.tz if isinstance(conf.tz, datetime.tzinfo) else ZoneInfo(conf.tz)
-            except Exception:
+            except (ZoneInfoNotFoundError, ValueError, TypeError):
                 target_tz = datetime.UTC
             dt = dt.astimezone(target_tz)
 


### PR DESCRIPTION
…invalid configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date formatting now handles missing or invalid timezone configurations by falling back to UTC, preventing errors when converting stored datetimes. This ensures consistent ISO-formatted timestamps are returned for database datetimes (including timezone-naive values) and avoids failures that could disrupt display or logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->