### PR TITLE
PLG: Enhance IP sorting in device table for correct numeric order #1606

### DIFF
--- a/front/js/network-api.js
+++ b/front/js/network-api.js
@@ -156,7 +156,15 @@ function loadDeviceTable({ sql, containerSelector, tableId, wrapperHtml = null, 
         {
           title: getString('Network_Table_IP'),
           data: 'devLastIP',
-          width: '5%'
+          width: '5%',
+          render: function (ip, type) {
+            if (type === 'sort') {
+              // Convert each octet to a zero-padded 3-digit string for correct numeric sort
+              if (!ip) return '';
+              return ip.split('.').map(o => o.padStart(3, '0')).join('.');
+            }
+            return ip || '';
+          }
         },
         {
           title: getString('Device_TableHead_Port'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IP addresses in the network device table now sort in proper numeric order instead of alphabetical string order, ensuring intuitive organization where 192.168.1.1 correctly precedes 192.168.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->